### PR TITLE
Change RSS to include items latest first

### DIFF
--- a/lib/PerlWeekly/Issue.pm
+++ b/lib/PerlWeekly/Issue.pm
@@ -228,7 +228,8 @@ sub process_rss {
 					date => $dateparser->format_datetime($dt)
 					,    #"${ts}T00:00:00+00:00",
 					     #    subject => 'list of tags?',
-				};
+				},
+			}
 		}
 	}
 

--- a/lib/PerlWeekly/Issue.pm
+++ b/lib/PerlWeekly/Issue.pm
@@ -205,6 +205,7 @@ sub process_rss {
 	);
 
 	#    $self->{header};
+	my @items;
 	foreach my $ch ( @{ $self->{chapters} } ) {
 
 		#$ch->{title}
@@ -217,7 +218,7 @@ sub process_rss {
 #die "Invalid ts format in " . Dumper $e if $e->{ts} =~ /^\d20\d\d\.\d\d\.\d\d$/;
 #my $ts = join '-', split /\./, $e->{ts};
 			$dt->add( seconds => 1 );
-			$rss->add_item(
+			push @items, {
 				title       => encode( 'utf-8', $e->{title} ),
 				link        => $e->{url},
 				description => encode( 'utf-8', $e->{text} ),
@@ -227,9 +228,13 @@ sub process_rss {
 					date => $dateparser->format_datetime($dt)
 					,    #"${ts}T00:00:00+00:00",
 					     #    subject => 'list of tags?',
-				},
-			);
+				};
 		}
+	}
+
+	# Add items so the latest comes first, as is convention on blogs/in rss:
+	foreach my $item (reverse @items) {
+		$rss->add_item(%$item);
 	}
 
 	#rss_item_count();

--- a/lib/PerlWeekly/Issue.pm
+++ b/lib/PerlWeekly/Issue.pm
@@ -192,7 +192,8 @@ sub process_rss {
 
 	my $text = join "\n", map {"<p>$_</p>"} @{ $self->{header} };
 
-	$rss->add_item(
+	my @items;
+	push @items, {
 		title => encode( 'utf-8', "#$self->{issue} - $self->{subject}" ),
 		link        => "${url}archive/$self->{issue}.html",
 		description => encode( 'utf-8', $text ),
@@ -202,10 +203,9 @@ sub process_rss {
 			date    => $dateparser->format_datetime($dt),
 			subject => 'list of tags?',
 		}
-	);
+	};
 
 	#    $self->{header};
-	my @items;
 	foreach my $ch ( @{ $self->{chapters} } ) {
 
 		#$ch->{title}


### PR DESCRIPTION
The convention in blogs and RSS feeds are that the order is descending (latest first).

This fork changes the RSS generated for Perl Weekly to follow that order, rather than e.g. having the introduction first in the feed.