### PR TITLE
doh, should have said File::Slurper, not File::Slurp

### DIFF
--- a/src/238.json
+++ b/src/238.json
@@ -119,7 +119,7 @@
             {
                "tags" : [],
                "title" : "Use Path::Tiny instead of home-made ReadFile and WriteFile",
-               "text" : "When refactoring tests for a module, Gabor noticed functions for reading and writing files. He shows how you can use <a href=\"https://metacpan.org/pod/Path::Tiny\">Path::Tiny</a> for this, and also mentions <a href=\"https://metacpan.org/pod/File::Slurp\">File::Slurp</a>, which is my go-to module for those tasks these days.",
+               "text" : "When refactoring tests for a module, Gabor noticed functions for reading and writing files. He shows how you can use <a href=\"https://metacpan.org/pod/Path::Tiny\">Path::Tiny</a> for this, and also mentions <a href=\"https://metacpan.org/pod/File::Slurper\">File::Slurper</a>, which is my go-to module for those tasks these days.",
                "author" : "gabor_szabo",
                "ts" : "2016.02.12",
                "url" : "http://perlmaven.com/use-path-tiny-instead-of-readfile-and-writefile"


### PR DESCRIPTION
ETHER pointed out that I mentioned the wrong module. I did indeed mean to say `File::Slurper`, not `File::Slurp` :-(

Can you update the web site please?

Thanks,
Neil
