### PR TITLE
correction on the MaxMind job listing (had email from DROLSKY)

### DIFF
--- a/src/258.json
+++ b/src/258.json
@@ -96,9 +96,9 @@
       {
          "entries" : [
             {
-               "title" : "MaxMind is looking to hire 2 Canadian Perl programmers",
+               "title" : "MaxMind is looking to hire 2 Perl programmers",
                "url" : "http://blog.urth.org/2016/06/28/maxmind-is-hiring-2/",
-               "text" : "MaxMind are looking for two Perl programmers, but seems like they need to be in Canada.",
+               "text" : "MaxMind are looking for two Perl programmers, but they need to be in the US states of Massachusetts, Minnesota, Montana, North Carolina, and Oregon, or anywhere in Canada.",
                "ts" : "2016.06.28",
                "author" : "dave_rolsky",
                "tags" : []


### PR DESCRIPTION
I had a correction from Dave Rolsky on where people can be based for their openings. I'm going to suggest he tweak his blog post, as the wording on his post gives the impression I got. The job listings are clear.

Can you republish the web version of today's issue please?

Cheers,
Neil
