### PR TITLE
fixed spelling issue, added info on Ben Cotton

### DIFF
--- a/src/authors.json
+++ b/src/authors.json
@@ -1266,7 +1266,7 @@
 	"anton_berezin" : {
 		"name" : "Anton Berezin",
 		"nick" : "tobez",
-		"pasue" : "GRUBER",
+		"pause" : "GRUBER",
 		"twitter" : "tobez",
 		"url" : "http://blogs.perl.org/users/tobez/",
 		"img" : "/img/anton_berezin.png"
@@ -1452,7 +1452,9 @@
 		"nick" : "ab5tract"
 	},
 	"ben_cotton" : {
-		"name" : "Ben Cotton"
+		"name" : "Ben Cotton",
+		"twitter" : "@funnelfiasco",
+		"url"  : "funnelfiasco.com"
 	},
 	"george_dunlap" : {
 		"name" : "George Dunlap"


### PR DESCRIPTION
I know Ben, so I added some details. 
In figuring out which details I could fill, I found that for anton_berezin, the field "pause" was spelled "pasue", and fixed that, too.