### PR TITLE
Remove entry titles from share-links div

### DIFF
--- a/tt/webpage.tt
+++ b/tt/webpage.tt
@@ -17,7 +17,7 @@
 </head>
 <body>
 <style>
-.share-links {
+.entry-title, .share-links {
   float: left;
   padding-right: 2px;
 }
@@ -123,12 +123,14 @@
                 [% END %]
                >
                <p style="margin-left: 1.5em;">
-               <div class="share-links">
+               <div class="entry-title">
                  <a href="[% e.url %]" style="
                     font-size: 18px;
                     font-weight: bold;
-                    ">[% e.title | html %]</a> <a href="http://twitter.com/home?status=[% e.twitter | html %]"><img src="http://perlweekly.com/img/twitter16.png" alt="Tweet"></a>
-
+                    ">[% e.title | html %]</a>
+               </div>
+               <div class="share-links">
+                 <a href="http://twitter.com/home?status=[% e.twitter | html %]"><img src="http://perlweekly.com/img/twitter16.png" alt="Tweet"></a>
                </div>
                <div class="share-links">
                  <a href="https://www.facebook.com/sharer/sharer.php?u=[% e.url %]"><img src="http://perlweekly.com/img/facebook16.png" alt="Facebook"></a>


### PR DESCRIPTION
This should prevent the titles from being blocked as social media links.