### PR TITLE
Adding events from The-Meetings-Page

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -3,9 +3,21 @@
     "entries" : [
             {
                "title" : "Chicago.pm",
-               "text" : "18:30 July 23, 2020 (America/Chicago UTC-5:00)",
+               "text" : "18:30 July 23, 2020 (America/Chicago UTC-5:00) (English)",
                "url" : "https://meet.google.com/aze-unbw-bcu",
                "ts" : "2020.07.23"
+            },
+            {
+               "title" : "Charlotte.pm",
+               "text" : "18:00 July 29, 2020 (America/New_York UTC-4:00) (English)",
+               "url" : "https://www.meetup.com/charlotte-pm/events/271954017",
+               "ts" : "2020.07.29"
+            },
+            {
+               "title" : "Amsterdam.pm",
+               "text" : "19:00 August 11, 2020 (Europe/Amsterdam (UTC+2:00) (Dutch/English)",
+               "url" : "https://meet.jit.si/amsterdam.pm",
+               "ts" : "2020.08.11"
             }
     ]
 }


### PR DESCRIPTION
Assuming that the text field is just printed, I took the liberty of adding the language. Also, for future reference, does JSON handle dangling commas? Example:

```json
            {
               "title" : "Amsterdam.pm",
               "text" : "19:00 August 11, 2020 (Europe/Amsterdam (UTC+2:00) (Dutch/English)",
               "url" : "https://meet.jit.si/amsterdam.pm",
               "ts" : "2020.08.11"
            }, ## danlging comma here
    ]
```