### PR TITLE
Correct the URL schema and revise plural.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -279,7 +279,7 @@
         </p>
         <hr>
         <p>
-        Proofreading help by <a href="https://www.shlomifish.org/">Shlomi Fish</a>, author of the <a href="httpis://perl-begin.org/">Perl Beginner's Site</a>.
+        Proofreading help by <a href="https://www.shlomifish.org/">Shlomi Fish</a>, author of the <a href="https://perl-begin.org/">Perl Beginners' Site</a>.
         </p>
         <hr>
         Inspired by <a href="https://javascriptweekly.com/">JavaScript Weekly</a> of <a href="http://peterc.org/">Peter Cooper</a>

--- a/tt/index.tt
+++ b/tt/index.tt
@@ -239,7 +239,7 @@
         </p>
         <hr>
         <p>
-        Proofreading help by <a href="https://www.shlomifish.org/">Shlomi Fish</a>, author of the <a href="httpis://perl-begin.org/">Perl Beginner's Site</a>.
+        Proofreading help by <a href="https://www.shlomifish.org/">Shlomi Fish</a>, author of the <a href="https://perl-begin.org/">Perl Beginners' Site</a>.
         </p>
         <hr>
         Inspired by <a href="https://javascriptweekly.com/">JavaScript Weekly</a> of <a href="http://peterc.org/">Peter Cooper</a>


### PR DESCRIPTION
"https://". Thanks to Leam for reporting that.