### PR TITLE
events: add Boston

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -14,6 +14,12 @@
                "begin" : "2021-04-08T18:00:00-05:00"
             },
             {
+               "title" : "Boston Perl Mongers Online Meeting: Mojolicious 9 point Oh! (Joel Berger)",
+               "text" : "Tuesday April 13th, 2021 07:00 PM Eastern Time (US and Canada)",
+               "url" : "https://boston.pm.org/bpm/Calendar",
+               "begin" : "2021-04-13T19:00:00-04:00"
+            },
+            {
                "title" : "Purdue Perl Mongers - HackLafayette",
                "text" : "Wednesday, April 14, 2021",
                "url" : "https://www.meetup.com/hacklafayette/",


### PR DESCRIPTION
Boston.pm is happy to join the PW calendar. 
(iCal format is a great addition!)