### PR TITLE
Boston URL needs homedir/ to avoid shared landing page

### DIFF
--- a/tt/events.tt
+++ b/tt/events.tt
@@ -40,7 +40,7 @@ If you'd like to get your event listed here, and if you'd like to promote your e
     <li><a href="https://www.meetup.com/Toronto-Perl-Mongers">Toronto Perl Mongers</a></li>
     <li><a href="https://houston.pm.org/">Houston Perl Mongers</a></li>
     <li><a href="https://www.meetup.com/Berlin-Perl-Mongers/">Berlin Perl Mongers</a></li>
-    <li><a href="https://boston.pm.org/">Boston Perl Mongers</a></li>
+    <li><a href="https://boston.pm.org/bpm/">Boston Perl Mongers</a></li>
     <li>---</li>
     <li><a href="https://www.meetup.com/The-New-York-Perl-Meetup-Group/">New York Perl Mongers</a></li>
     <li><a href="https://www.meetup.com/London-Perl-Mongers/">London Perl Mongers</a></li>


### PR DESCRIPTION
( as is "works" but requires second click on our logo instead of the Linux group logo or host's demo wiki logo. )