### PR TITLE
Boston PM May 2023; no Charlotte scheduled

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -4,10 +4,10 @@
  
 
             {
-               "title" : "Charlotte PM : I <3 Smol backend (and I cannot lie) - Yanick ",
-               "text" : "Wednesday Oct 26th, 2022 06:00 PM Eastern Time (US and Canada)",
-               "url" : "https://www.meetup.com/charlotte-pm/events/289085740/",
-               "begin" : "2022-10-26T18:00:00-04:00"
+               "title" : "Boston PM : Corinna, feature class, Object::Pad - Paul 'LeoNerd' Evans (live; with Ovid on tape delay)",
+               "text" : "Tuesday Mar 14th, 2022 06:30 PM Eastern Time (US and Canada)",
+               "url" : "https://boston-pm.github.io/#schedule",
+               "begin" : "2023-03-14T18:30:00-04:00"
             }
     ]
 }


### PR DESCRIPTION
Featuring Corinna on PI Day 3.14 (USA m.dd date order), with LeoNerd live and Ovid on tape delay