### PR TITLE
Boston.PM time, winter TZ, URL

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -1,10 +1,10 @@
 {
    "entries" : [
       {
-         "begin" : "2025-02-11T19:30:00-04:00",
+         "begin" : "2025-02-11T19:00:00-05:00",
          "text" : "Virtual event",
-         "title" : "Boston.pm monthly meeting",
-         "url" : "https://www.meetup.com/Boston-pm/"
+         "title" : "Boston.pm monthly meeting: Perl 5.41 beta; new socials",
+         "url" : "https://boston.pm.org/index.html#schedule"
       },
       {
          "begin" : "2025-02-12T20:00:00+01:00",
@@ -13,10 +13,10 @@
          "url" : "https://paris.mongueurs.net/"
       },
       {
-         "begin" : "2025-03-11T19:30:00-04:00",
+         "begin" : "2025-03-11T19:00:00-04:00",
          "text" : "Virtual event",
          "title" : "Boston.pm monthly meeting",
-         "url" : "https://www.meetup.com/Boston-pm/"
+         "url" : "https://boston.pm.org/index.html#schedule"
       },
       {
          "begin" : "2025-03-12T20:00:00+01:00",
@@ -25,10 +25,10 @@
          "url" : "https://paris.mongueurs.net/"
       },
       {
-         "begin" : "2025-04-08T19:30:00-04:00",
+         "begin" : "2025-04-08T19:00:00-04:00",
          "text" : "Virtual event",
          "title" : "Boston.pm monthly meeting",
-         "url" : "https://www.meetup.com/Boston-pm/"
+         "url" : "https://boston.pm.org/index.html#schedule"
       },
       {
          "begin" : "2025-05-12T09:00:00+02:00",


### PR DESCRIPTION
Boston is UTC-0500 in winter (EST aka NewYork),
UTC-0400 in summer (EDT aka NewYork)
In this new millenium, Summer starts usually
before our March meeting and ends just before
November meeting.
(While it's too late to publish tonight's meeting with correct TZ, adjusting that entry may set it right in history?)

I've adjusted from 1930 to 1900 to mark that we convene 1900 local.

Our new URL is https://boston.pm.org/index.html#schedule Our MeetUp (as noted by Gabor elsewhere) is defunct.

(Looking at `events.tt`, I've no update for that, since we're commented and imported via TT as long as we've got `events.json` entries.)

Thanks. -- Bill in Boston