### PR TITLE
Remove link to obvious crypto scam

### DIFF
--- a/src/716.json
+++ b/src/716.json
@@ -36,13 +36,6 @@
                "url" : "https://cpanscan.com/"
             },
             {
-               "author" : "",
-               "text" : "I am not into Crypto, so don't know enough to judge this. It sounds too good to be true, though.",
-               "title" : "Start Earning Big with Perlin $PERL Staking Rewards",
-               "ts" : "2025.04.11",
-               "url" : "https://medium.com/@ialbinalarionova47/maximize-your-passive-income-with-perlin-perl-1474fd8370b1"
-            },
-            {
                "author" : "ted_james",
                "text" : "Currently I am developing an ASP.NET application that for legacy reasons needs to execute some Perl scripts. For this I wrote a small C++ library that uses the embedded Perl API.",
                "title" : "Multiple embedded Perl instances in multithreaded environment",


### PR DESCRIPTION
Sorry, this is partly my fault. These links have been appearing on the Medium Perl tag for a while now - so they're shown on Planet Perl. I think I've stopped that now.

If you've sent the email out, I'd seriously consider a follow-up email to subscribers, asking them not to click that link.