### PR TITLE
Moved the share buttons to tt/share.tt. Remove all Twitter sharing

### DIFF
--- a/tt/mail.tt
+++ b/tt/mail.tt
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
   <title>Perl Weekly Issue #[% issue %] - [% date %] - [% subject %]</title>
+  <script defer src="https://static.addtoany.com/menu/page.js"></script>
 </head>
 <body>
 
@@ -126,7 +127,7 @@ a { color: #04c; }
                   font-size: 18px;
                   font-weight: bold;
                   ">[% e.title | html %]</a>
-               <a href="https://twitter.com/home?status=[% e.twitter | html %]"><img src="https://perlweekly.com/img/twitter16.png" alt="Tweet"></a>
+[% INCLUDE tt/share.tt %]
                <br />
                [%- IF e.author -%]
                  <span style="font-size: 14px"> 
@@ -146,7 +147,7 @@ a { color: #04c; }
                </p>
                [% IF social_links %]
                  <br />
-                 <a href="https://twitter.com/home?status=[% e.title %] [% e.url %] via @perlweekly">Tweet</a>
+[% INCLUDE tt/share.tt %]
                [% END %]
                </div>
            [% IF e.img %]</td><td style="width:100px"><img src="[% UNLESS web %]https://perlweekly.com[% END %][% e.img %]" title="[% e.img_title %]" width="80" />[% END %]

--- a/tt/share.tt
+++ b/tt/share.tt
@@ -1,0 +1,10 @@
+                 <div class="a2a_kit a2a_kit_size_16 a2a_default_style"
+[% IF e -%]
+                   data-a2a-url="[% e.url %]" data-a2a-title="[% e.title %]"
+[% END -%]
+>
+                   <a class="a2a_button_twitter"></a>
+                   <a class="a2a_button_facebook"></a>
+                   <a class="a2a_button_email"></a>
+                   <a class="a2a_dd" href="https://www.addtoany.com/share"></a>
+                 </div>

--- a/tt/webpage.tt
+++ b/tt/webpage.tt
@@ -68,11 +68,7 @@
 
     <p>
 
-    <a href="https://twitter.com/share" class="twitter-share-button"
-    data-text="Perl Weekly: [% subject %] via @perlweekly" data-count="vertical">Tweet</a>
-    <script type="text/javascript" src="https://platform.twitter.com/widgets.js">
-    </script>
-
+[% INCLUDE tt/share.tt %]
 
 </td></tr>
 
@@ -124,13 +120,7 @@
                     ">[% e.title | html %]</a>
                </div>
                <div class="share-links">
-                 <div class="a2a_kit a2a_kit_size_16 a2a_default_style"
-                   data-a2a-url="[% e.url %]" data-a2a-title="[% e.title %]">
-                   <a class="a2a_button_twitter"></a>
-                   <a class="a2a_button_facebook"></a>
-                   <a class="a2a_button_email"></a>
-                   <a class="a2a_dd" href="https://www.addtoany.com/share"></a>
-                 </div>
+[% INCLUDE tt/share.tt %]
                </div>
 
                <br />
@@ -152,7 +142,7 @@
                </p>
                [% IF social_links %]
                  <br />
-                 <a href="https://twitter.com/home?status=[% e.title %] [% e.url %] via @perlweekly">Tweet</a>
+[% INCLUDE tt/share.tt %]
                [% END %]
                </div>
            [% IF e.img %]</td><td style="width:100px"><img src="[% UNLESS web %]https://perlweekly.com[% END %][% e.img %]" title="[% e.img_title %]" width="80" />[% END %]


### PR DESCRIPTION
I think this has got everything.

There are still references to Twitter accounts, but I think that's ok. All sharing buttons (both on the web and in the email) now use AddToAny.