### PR TITLE
update events.json for Boston.pm

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -3,7 +3,7 @@
       {
          "begin" : "2025-09-09T19:30:00-04:00",
          "text" : "September 9, 2025",
-         "title" : "Boston.pm - online - monthly meeting",
+         "title" : "Boston.pm - online - monthly meetings resume (2d Tuesday)",
          "url" : "https://boston-pm.github.io/"
       },
       {


### PR DESCRIPTION
unlike previous 2 summer months, standard monthly text was correct (until DST ends!) but vague, so added "resumes"