### PR TITLE
Update events.json For Toronto.pm

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -13,7 +13,7 @@
          "url" : "https://luma.com/perl-maven"
       },
       {
-         "begin" : "2025-12-06T13:00:00-04:00",
+         "begin" : "2025-12-06T18:00:00-00:00",
          "text" : "December 6, 2025",
          "title" : "Toronto.pm - online - How SUSE is using Perl",
          "url" : "https://lu.ma/v90mkqj5"


### PR DESCRIPTION
Update the time to be in UTC. The event is at 1300 local time and 1800 UTC. Please see the lu.ma page for authoritative information.