### PR TITLE
Boston.pm Jan 2026

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -7,6 +7,12 @@
          "url" : "https://paris.mongueurs.net/"
       },
       {
+         "begin" : "2026-01-13T19:00:00-05:00",
+         "text" : "January 13, 2025",
+         "title" : "Boston.pm - online ",
+         "url" : "https://mobilizon.us/search?search=Boston+Perl"
+      },
+      {
          "begin" : "2026-03-16T08:00:00+01:00",
          "text" : "March 16-18, 2025",
          "title" : "German Perl/Raku Workshop 2026 in Berlin",


### PR DESCRIPTION
events.json add January 2026 Boston

(FWIW Mobilizon link is unchanging because it's a search to find all planned one(s).)