### PR TITLE
cancel Boston January, set February

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -7,16 +7,16 @@
          "url" : "https://luma.com/perl-maven"
       },
       {
-         "begin" : "2026-01-13T19:00:00-05:00",
-         "text" : "January 13, 2025",
-         "title" : "Boston.pm - online ",
-         "url" : "https://mobilizon.us/search?search=Boston+Perl"
-      },
-      {
          "begin" : "2026-01-24T20:00:00+02:00",
          "text" : "January 24, 2025",
          "title" : "Perl Maven online: Live Open Source contribution",
          "url" : "https://luma.com/perl-maven"
+      },
+      {
+         "begin" : "2026-02-10T19:00:00-05:00",
+         "text" : "February 10, 2025",
+         "title" : "Boston.pm - online ",
+         "url" : "https://mobilizon.us/search?search=Boston+Perl"
       },
       {
          "begin" : "2026-03-16T08:00:00+01:00",


### PR DESCRIPTION
I have to cancel next week so I'm pushing next month at the same time.
(linked Mobilzon Events and our Homepage already tweaked a few minutes ago.)