### PR TITLE
April 14th Boston added. 

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -7,6 +7,12 @@
          "url" : "https://luma.com/perl-maven"
       },
       {
+         "begin" : "2026-04-14T19:00:00-04:00",
+         "text" : "April 14, 2026",
+         "title" : "Boston Perl Mongers virtual monthly",
+         "url" : "https://boston.pm.org/"
+      },
+      {
          "begin" : "2026-04-16T17:00:00+01:00",
          "text" : "April 16, 2026",
          "title" : "Perl Maven online: Testing in Perl - part 4",


### PR DESCRIPTION
(TZ `New York` aka US Eastern now on Summer or Daylight Savings Time AKA `EDT` so `UTC-4` instead of `UTC-5`.)
(Sorry i missed posting last month)