### PR TITLE
Boston July added

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -1,12 +1,6 @@
 {
    "entries" : [
       {
-         "begin" : "2026-06-09T19:00:00-04:00",
-         "text" : "June 9, 2026",
-         "title" : "Boston Perl Mongers virtual monthly",
-         "url" : "https://boston.pm.org/"
-      },
-      {
          "begin" : "2026-06-10T20:00:00+01:00",
          "text" : "June 10, 2026",
          "title" : "Paris.pm monthly meeting",
@@ -41,6 +35,12 @@
          "text" : "June 26-29, 2026, Greenville, SC, USA",
          "title" : "The Perl and Raku Conference 2026",
          "url" : "https://tprc.us/tprc-2026-gsp/"
+      },
+      {
+         "begin" : "2026-07-14T19:00:00-04:00",
+         "text" : "July 14, 2026",
+         "title" : "Boston Perl Mongers virtual monthly",
+         "url" : "https://boston.pm.org/"
       }
    ],
    "title" : "Events"


### PR DESCRIPTION
delete June Boston, add July Boston.,
[Note, we typically skip August Technical so unless we have a Social, next event will be September.],
[I do wish JSON allowed trailing , as Perl does; moving first to last is doubly fraught in any language other than Perl!],