### PR TITLE
Boston September (events.json)

### DIFF
--- a/src/events.json
+++ b/src/events.json
@@ -13,6 +13,12 @@
          "url" : "https://luma.com/obzvoiii"
       },
       {
+         "begin" : "2026-09-08T19:00:00-04:00",
+         "text" : "September 8, 2026",
+         "title" : "Boston Perl Mongers virtual monthly",
+         "url" : "https://boston.pm.org/"
+      },
+      {
          "begin" : "2026-09-09T17:30:00-04:00",
          "text" : "September 9, 2026",
          "title" : "Purdue Perl Mongers (HackLafayette) - TBA",


### PR DESCRIPTION
Boston restarts September annually, having skipped August conventionally.